### PR TITLE
closes #32 and handles the case where there is no bed file but you wa…

### DIFF
--- a/scripts/assess_assembly
+++ b/scripts/assess_assembly
@@ -36,7 +36,7 @@ while getopts ':hr:i:p:c:CTt:b:' option; do
     p  ) PREFIX=$OPTARG;;
     c  ) CHUNK=$OPTARG;;
     C  ) catalogue_flag=true; ALIGN_OPTS="-m";;
-    T  ) trim_flag=true;;
+    T  ) trim_flag=true; ALIGN_OPTS="-m";;
     t  ) THREADS=$OPTARG;;
     b  ) bed_flag=true; BED="--bed $OPTARG"; ALIGN_OPTS="-m";;
     \? ) echo "Invalid option: -${OPTARG}." >&2; exit 1;;


### PR DESCRIPTION
Hello, this one little change allows us to run `assess_assembly` in the case where we don't have a bed file but still want to use `-T`. I have tested this code with and without bed files, and it works OK. It would be great if you guys can make this change, so we don't have to do this edit manually every time we install Pomoxis. 

Thanks.