### PR TITLE
Closes #36 (Adds -l functionality to ignore long indels from assess_assembly)

### DIFF
--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -83,10 +83,14 @@ def count_from_cigartuples(cigartuples, longest_indel):
         if cigar_op == 1:
             if longest_indel == 0 or cigar_len <= longest_indel:
                 ins += cigar_len
+            else:
+                print('Skipping ins {}:{}'.format(cigar_op, cigar_len))
         # delt
         if cigar_op == 2:
             if longest_indel == 0 or cigar_len <= longest_indel:
                 delt += cigar_len
+            else:
+                print('Skipping ins {}:{}'.format(cigar_op, cigar_len))
 
     return match, ins, delt
 

--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -75,22 +75,35 @@ def count_from_cigartuples(cigartuples, longest_indel):
 
     """
     match, ins, delt = 0, 0, 0
+    from collections import defaultdict
+    insert_len_frequency = defaultdict(int)
+    delete_len_frequency = defaultdict(int)
+
     for cigar_op, cigar_len in cigartuples:
         # match
         if cigar_op == 0:
             match += cigar_len
         # insert
         if cigar_op == 1:
+            insert_len_frequency[cigar_len] += 1
+
             if longest_indel == 0 or cigar_len <= longest_indel:
                 ins += cigar_len
             else:
-                print('Skipping ins {}:{}'.format(cigar_op, cigar_len))
+                print('Skipping IN {}:{}'.format(cigar_op, cigar_len))
         # delt
         if cigar_op == 2:
+            delete_len_frequency[cigar_len] += 1
             if longest_indel == 0 or cigar_len <= longest_indel:
                 delt += cigar_len
             else:
-                print('Skipping ins {}:{}'.format(cigar_op, cigar_len))
+                print('Skipping DEL {}:{}'.format(cigar_op, cigar_len))
+
+    for in_len, count in insert_len_frequency:
+        print("INSERT LENGTH: ", in_len, " COUNT: ", count)
+    print("############################")
+    for del_len, count in delete_len_frequency:
+        print("DELETE LENGTH: ", in_len, " COUNT: ", count)
 
     return match, ins, delt
 

--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -18,6 +18,10 @@ parser = argparse.ArgumentParser(
     description="""Parse a bamfile (from a stream) and output summary stats for each read.""",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
+from collections import defaultdict
+insert_len_frequency = defaultdict(int)
+delete_len_frequency = defaultdict(int)
+
 parser.add_argument('bam', type=str, help='Path to bam file.')
 parser.add_argument('--bed', default=None, help='.bed file of reference regions to include.')
 parser.add_argument('-m', '--min_length', type=int, default=None)
@@ -75,9 +79,6 @@ def count_from_cigartuples(cigartuples, longest_indel):
 
     """
     match, ins, delt = 0, 0, 0
-    from collections import defaultdict
-    insert_len_frequency = defaultdict(int)
-    delete_len_frequency = defaultdict(int)
 
     for cigar_op, cigar_len in cigartuples:
         # match
@@ -98,12 +99,6 @@ def count_from_cigartuples(cigartuples, longest_indel):
                 delt += cigar_len
             else:
                 print('Skipping DEL {}:{}'.format(cigar_op, cigar_len))
-
-    for in_len, count in insert_len_frequency.items():
-        print("INSERT LENGTH: ", in_len, " COUNT: ", count)
-    print("############################")
-    for del_len, count in delete_len_frequency.items():
-        print("DELETE LENGTH: ", del_len, " COUNT: ", count)
 
     return match, ins, delt
 
@@ -494,6 +489,12 @@ def main(arguments=None):
         raise ValueError('No alignments processed. Check your bam and filtering options.')
 
     args.summary.write('Mapped/Unmapped/Short/Masked: {total}/{unmapped}/{short}/{masked}\n'.format_map(counts))
+
+    for in_len, count in insert_len_frequency.items():
+        print("INSERT LENGTH: ", in_len, " COUNT: ", count)
+    print("############################")
+    for del_len, count in delete_len_frequency.items():
+        print("DELETE LENGTH: ", del_len, " COUNT: ", count)
 
 
 if __name__ == '__main__':

--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -256,7 +256,7 @@ def masked_stats_from_aligned_read_excluding_longindels(read, references, length
         if not tree.overlaps(pos) or (rp is None and not tree.overlaps(pos + 1)):
             # if rp is None, we are in an insertion, check if pos + 1 overlaps
             # (ref position of ins is arbitrary)
-            print('Skipping ref {}:{}'.format(read.reference_name, pos))
+            # print('Skipping ref {}:{}'.format(read.reference_name, pos))
             masked += 1
 
             # check if the previous operation is complete due to this

--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -490,10 +490,10 @@ def main(arguments=None):
 
     args.summary.write('Mapped/Unmapped/Short/Masked: {total}/{unmapped}/{short}/{masked}\n'.format_map(counts))
 
-    for in_len, count in insert_len_frequency.items():
+    for in_len, count in sorted(insert_len_frequency.items()):
         print("INSERT LENGTH: ", in_len, " COUNT: ", count)
     print("############################")
-    for del_len, count in delete_len_frequency.items():
+    for del_len, count in sorted(delete_len_frequency.items()):
         print("DELETE LENGTH: ", del_len, " COUNT: ", count)
 
 

--- a/pomoxis/common/stats_from_bam.py
+++ b/pomoxis/common/stats_from_bam.py
@@ -99,11 +99,11 @@ def count_from_cigartuples(cigartuples, longest_indel):
             else:
                 print('Skipping DEL {}:{}'.format(cigar_op, cigar_len))
 
-    for in_len, count in insert_len_frequency:
+    for in_len, count in insert_len_frequency.items():
         print("INSERT LENGTH: ", in_len, " COUNT: ", count)
     print("############################")
-    for del_len, count in delete_len_frequency:
-        print("DELETE LENGTH: ", in_len, " COUNT: ", count)
+    for del_len, count in delete_len_frequency.items():
+        print("DELETE LENGTH: ", del_len, " COUNT: ", count)
 
     return match, ins, delt
 

--- a/scripts/assess_assembly
+++ b/scripts/assess_assembly
@@ -14,11 +14,13 @@ Calculate accuracy statistics for an assembly.
     -t  alignment threads (default: 1).
     -p  output file prefix (default: assm).
     -T  trim consensus to primary alignments of truth to assembly.
-    -b  .bed file of reference regions to assess."
+    -b  .bed file of reference regions to assess.
+    -l  ignore insertions and deletions longer than this value, 0 means include everything. (default 0)"
 
 PREFIX="assm"
 THREADS=1
 CHUNK="100000"
+LONGEST_INDEL_LENGTH=0
 rflag=false
 iflag=false
 bed_flag=false
@@ -28,7 +30,7 @@ ALIGN_OPTS=""
 BED=""
 
 
-while getopts ':hr:i:p:c:CTt:b:' option; do
+while getopts ':hr:i:p:c:CTt:b:l:' option; do
   case "$option" in
     h  ) echo "$usage" >&2; exit;;
     r  ) rflag=true; REFERENCE=$OPTARG;;
@@ -39,6 +41,7 @@ while getopts ':hr:i:p:c:CTt:b:' option; do
     T  ) trim_flag=true; ALIGN_OPTS="-m";;
     t  ) THREADS=$OPTARG;;
     b  ) bed_flag=true; BED="--bed $OPTARG"; ALIGN_OPTS="-m";;
+    l  ) LONGEST_INDEL_LENGTH=$OPTARG;;
     \? ) echo "Invalid option: -${OPTARG}." >&2; exit 1;;
     :  ) echo "Option -$OPTARG requires an argument." >&2; exit 1;;
   esac
@@ -67,7 +70,7 @@ STATS_THREADS=1
 if [[ "$BED" != "" ]]; then
     STATS_THREADS=$THREADS
 fi
-stats_from_bam ${PREFIX}.bam -o ${PREFIX}_stats.txt -t ${STATS_THREADS} ${BED} 
+stats_from_bam ${PREFIX}.bam -o ${PREFIX}_stats.txt -t ${STATS_THREADS} ${BED} -l ${LONGEST_INDEL_LENGTH}
 
 summary_from_stats -i ${PREFIX}_stats.txt -pr -o ${PREFIX}_summ.txt
 


### PR DESCRIPTION
Changes:
stats_from_bam.py:
Now takes the `-l` parameter to define the longest allowed insertion or deletion. The default is 0 in which it'll count everything. `stats_from_aligned_read` is changed and `masked_stats_from_aligned_read_excluding_longindels` is newly added. 

The assess_assembly script is also changed to have the `-l` parameter.